### PR TITLE
fix: reduce cyclomatic complexity in XML and INI parsers

### DIFF
--- a/pkg/core/config/parser/args_test.go
+++ b/pkg/core/config/parser/args_test.go
@@ -318,6 +318,121 @@ func TestARGS_ParseArgsStrict(t *testing.T) {
 	}
 }
 
+func TestARGS_NewHelperFunctions(t *testing.T) {
+	a := NewARGS(false)
+
+	t.Run("isFlag", func(t *testing.T) {
+		tests := []struct {
+			arg  string
+			want bool
+		}{
+			{"-f", true},
+			{"--flag", true},
+			{"", false},
+			{"value", false},
+		}
+
+		for _, tt := range tests {
+			got := a.isFlag(tt.arg)
+			if got != tt.want {
+				t.Errorf("isFlag(%q) = %v, want %v", tt.arg, got, tt.want)
+			}
+		}
+	})
+
+	t.Run("stripDashesOptimized", func(t *testing.T) {
+		tests := []struct {
+			arg  string
+			want string
+		}{
+			{"--flag", "flag"},
+			{"-f", "f"},
+			{"---triple", "-triple"},
+		}
+
+		for _, tt := range tests {
+			got := a.stripDashesOptimized(tt.arg)
+			if got != tt.want {
+				t.Errorf("stripDashesOptimized(%q) = %v, want %v", tt.arg, got, tt.want)
+			}
+		}
+	})
+
+	t.Run("extractKeyValue", func(t *testing.T) {
+		args := []string{"--key=value", "--flag", "value", "--bool"}
+
+		// Test key=value format
+		key, value, skip := a.extractKeyValue("key=value", args, 0)
+		if key != "key" || value != "value" || skip != 0 {
+			t.Errorf("extractKeyValue with = got key=%v, value=%v, skip=%v", key, value, skip)
+		}
+
+		// Test flag with next value
+		key, value, skip = a.extractKeyValue("flag", args[1:], 0)
+		if key != "flag" || value != "value" || skip != 1 {
+			t.Errorf("extractKeyValue with next value got key=%v, value=%v, skip=%v", key, value, skip)
+		}
+
+		// Test boolean flag at end
+		key, value, skip = a.extractKeyValue("bool", args[3:], 0)
+		if key != "bool" || value != "true" || skip != 0 {
+			t.Errorf("extractKeyValue boolean got key=%v, value=%v, skip=%v", key, value, skip)
+		}
+	})
+}
+
+func TestARGS_HandleFlagValue(t *testing.T) {
+	a := NewARGS(false)
+
+	tests := []struct {
+		name     string
+		key      string
+		args     []string
+		index    int
+		wantKey  string
+		wantVal  string
+		wantSkip int
+	}{
+		{
+			name:     "negative number value",
+			key:      "threshold",
+			args:     []string{"--threshold", "-10"},
+			index:    0,
+			wantKey:  "threshold",
+			wantVal:  "-10",
+			wantSkip: 1,
+		},
+		{
+			name:     "no next arg",
+			key:      "flag",
+			args:     []string{"--flag"},
+			index:    0,
+			wantKey:  "flag",
+			wantVal:  "true",
+			wantSkip: 0,
+		},
+		{
+			name:     "next arg is flag",
+			key:      "flag1",
+			args:     []string{"--flag1", "--flag2"},
+			index:    0,
+			wantKey:  "flag1",
+			wantVal:  "true",
+			wantSkip: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotKey, gotVal, gotSkip := a.handleFlagValue(tt.key, tt.args, tt.index)
+			if gotKey != tt.wantKey || gotVal != tt.wantVal || gotSkip != tt.wantSkip {
+				t.Errorf("handleFlagValue() = (%v, %v, %v), want (%v, %v, %v)",
+					gotKey, gotVal, gotSkip, tt.wantKey, tt.wantVal, tt.wantSkip)
+			}
+		})
+	}
+}
+
 func TestARGS_ParseArgsStrict_EdgeCases(t *testing.T) {
 	parser := NewARGS(false)
 

--- a/pkg/core/config/parser/env_test.go
+++ b/pkg/core/config/parser/env_test.go
@@ -270,6 +270,125 @@ func TestENV_EmptyPrefix(t *testing.T) {
 	}
 }
 
+func TestENV_HelperFunctions(t *testing.T) {
+	e := NewENV("APP")
+
+	t.Run("countMatchingVars", func(t *testing.T) {
+		// Set up test environment
+		os.Setenv("APP_KEY1", "value1")
+		os.Setenv("APP_KEY2", "value2")
+		os.Setenv("OTHER_KEY", "value3")
+		os.Setenv("INVALID", "") // Will be skipped - no =
+		defer os.Unsetenv("APP_KEY1")
+		defer os.Unsetenv("APP_KEY2")
+		defer os.Unsetenv("OTHER_KEY")
+		defer os.Unsetenv("INVALID")
+
+		envVars := os.Environ()
+		count := e.countMatchingVars(envVars)
+		// Should count APP_KEY1 and APP_KEY2
+		if count < 2 {
+			t.Errorf("countMatchingVars() = %d, want at least 2", count)
+		}
+	})
+
+	t.Run("parseEnvVar", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			env       string
+			prefix    string
+			wantKey   string
+			wantValue string
+			wantOk    bool
+		}{
+			{
+				name:      "valid with prefix match",
+				env:       "APP_KEY=value",
+				prefix:    "APP",
+				wantKey:   "KEY",
+				wantValue: "value",
+				wantOk:    true,
+			},
+			{
+				name:      "no equals sign",
+				env:       "INVALID",
+				prefix:    "",
+				wantKey:   "",
+				wantValue: "",
+				wantOk:    false,
+			},
+			{
+				name:      "prefix mismatch",
+				env:       "OTHER_KEY=value",
+				prefix:    "APP",
+				wantKey:   "",
+				wantValue: "",
+				wantOk:    false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				e := NewENV(tt.prefix)
+				key, value, ok := e.parseEnvVar(tt.env)
+				if key != tt.wantKey || value != tt.wantValue || ok != tt.wantOk {
+					t.Errorf("parseEnvVar(%q) = (%q, %q, %v), want (%q, %q, %v)",
+						tt.env, key, value, ok, tt.wantKey, tt.wantValue, tt.wantOk)
+				}
+			})
+		}
+	})
+
+	t.Run("processPrefix", func(t *testing.T) {
+		// processPrefix assumes the prefix has already been removed,
+		// so we test with keys that start after the prefix
+		e := NewENV("APP")
+		tests := []struct {
+			key  string
+			want string
+		}{
+			{"APP_KEY", "KEY"}, // Remove prefix and underscore
+			{"APPKEY", "KEY"},  // Remove prefix, no underscore
+			{"APP_", ""},       // Just prefix and underscore
+			{"APP", ""},        // Just prefix
+		}
+
+		for _, tt := range tests {
+			got := e.processPrefix(tt.key)
+			if got != tt.want {
+				t.Errorf("processPrefix(%q) = %q, want %q", tt.key, got, tt.want)
+			}
+		}
+	})
+}
+
+func TestENV_LoadFiltered_EdgeCases(t *testing.T) {
+	// Test LoadFiltered with various scenarios
+	os.Setenv("FILTER_YES", "include")
+	os.Setenv("FILTER_NO", "exclude")
+	os.Setenv("INVALID", "") // No equals sign - should handle gracefully
+	defer os.Unsetenv("FILTER_YES")
+	defer os.Unsetenv("FILTER_NO")
+	defer os.Unsetenv("INVALID")
+
+	env := NewENV("")
+	result, err := env.LoadFiltered(func(s string) bool {
+		return strings.HasPrefix(s, "FILTER_YES")
+	})
+
+	if err != nil {
+		t.Fatalf("LoadFiltered() error = %v", err)
+	}
+
+	if result["filter.yes"] != "include" {
+		t.Errorf("filter.yes = %q, want %q", result["filter.yes"], "include")
+	}
+
+	if _, exists := result["filter.no"]; exists {
+		t.Error("filter.no should not exist (filtered out)")
+	}
+}
+
 func TestENV_PrefixEdgeCases(t *testing.T) {
 	// Test edge cases with prefix matching
 	testVars := map[string]string{

--- a/pkg/core/config/parser/ini.go
+++ b/pkg/core/config/parser/ini.go
@@ -189,26 +189,32 @@ func (i *INI) trimBytes(b []byte) []byte {
 }
 
 func (i *INI) trimLeftBytes(b []byte) []byte {
-	for len(b) > 0 && i.isWhitespaceINI(b[0]) {
+	for len(b) > 0 && i.isTrimWhitespace(b[0]) {
 		b = b[1:]
 	}
 	return b
 }
 
 func (i *INI) trimRightBytes(b []byte) []byte {
-	for len(b) > 0 && i.isWhitespaceINI(b[len(b)-1]) {
+	for len(b) > 0 && i.isTrimWhitespace(b[len(b)-1]) {
 		b = b[:len(b)-1]
 	}
 	return b
 }
 
-func (i *INI) isWhitespaceINI(ch byte) bool {
+// isTrimWhitespace checks if a byte is whitespace for trimming (space, tab, carriage return)
+func (i *INI) isTrimWhitespace(ch byte) bool {
 	return ch == ' ' || ch == '\t' || ch == '\r'
 }
 
-// trimRight removes trailing whitespace from bytes.
+// isLineEndWhitespace checks if a byte is line-end whitespace (space, tab only)
+func (i *INI) isLineEndWhitespace(ch byte) bool {
+	return ch == ' ' || ch == '\t'
+}
+
+// trimRight removes trailing whitespace from bytes (excludes \r).
 func (i *INI) trimRight(b []byte) []byte {
-	for len(b) > 0 && (b[len(b)-1] == ' ' || b[len(b)-1] == '\t') {
+	for len(b) > 0 && i.isLineEndWhitespace(b[len(b)-1]) {
 		b = b[:len(b)-1]
 	}
 	return b

--- a/pkg/core/config/parser/ini.go
+++ b/pkg/core/config/parser/ini.go
@@ -183,13 +183,27 @@ func (i *INI) processValue(value []byte) []byte {
 
 // trimBytes removes leading and trailing whitespace from bytes.
 func (i *INI) trimBytes(b []byte) []byte {
-	for len(b) > 0 && (b[0] == ' ' || b[0] == '\t' || b[0] == '\r') {
+	b = i.trimLeftBytes(b)
+	b = i.trimRightBytes(b)
+	return b
+}
+
+func (i *INI) trimLeftBytes(b []byte) []byte {
+	for len(b) > 0 && i.isWhitespaceINI(b[0]) {
 		b = b[1:]
 	}
-	for len(b) > 0 && (b[len(b)-1] == ' ' || b[len(b)-1] == '\t' || b[len(b)-1] == '\r') {
+	return b
+}
+
+func (i *INI) trimRightBytes(b []byte) []byte {
+	for len(b) > 0 && i.isWhitespaceINI(b[len(b)-1]) {
 		b = b[:len(b)-1]
 	}
 	return b
+}
+
+func (i *INI) isWhitespaceINI(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\r'
 }
 
 // trimRight removes trailing whitespace from bytes.

--- a/pkg/core/config/parser/ini_test.go
+++ b/pkg/core/config/parser/ini_test.go
@@ -655,6 +655,135 @@ func (r *errorReader) Read(p []byte) (n int, err error) {
 	return 0, r.err
 }
 
+func TestINI_WhitespaceFunctions(t *testing.T) {
+	i := &INI{}
+
+	t.Run("isTrimWhitespace", func(t *testing.T) {
+		tests := []struct {
+			ch   byte
+			want bool
+		}{
+			{' ', true},
+			{'\t', true},
+			{'\r', true},
+			{'\n', false},
+			{'a', false},
+		}
+
+		for _, tt := range tests {
+			got := i.isTrimWhitespace(tt.ch)
+			if got != tt.want {
+				t.Errorf("isTrimWhitespace(%q) = %v, want %v", tt.ch, got, tt.want)
+			}
+		}
+	})
+
+	t.Run("isLineEndWhitespace", func(t *testing.T) {
+		tests := []struct {
+			ch   byte
+			want bool
+		}{
+			{' ', true},
+			{'\t', true},
+			{'\r', false},
+			{'\n', false},
+			{'a', false},
+		}
+
+		for _, tt := range tests {
+			got := i.isLineEndWhitespace(tt.ch)
+			if got != tt.want {
+				t.Errorf("isLineEndWhitespace(%q) = %v, want %v", tt.ch, got, tt.want)
+			}
+		}
+	})
+
+	t.Run("trimRight functionality", func(t *testing.T) {
+		// trimRight only removes space and tab from the end (not \r)
+		tests := []struct {
+			input    []byte
+			expected []byte
+			desc     string
+		}{
+			{
+				input:    []byte("test  \t"),
+				expected: []byte("test"),
+				desc:     "removes trailing spaces and tabs",
+			},
+			{
+				input:    []byte("test"),
+				expected: []byte("test"),
+				desc:     "no trailing whitespace",
+			},
+			{
+				input:    []byte("test\r"),
+				expected: []byte("test\r"),
+				desc:     "preserves \\r",
+			},
+			{
+				input:    []byte("test\r  "),
+				expected: []byte("test\r"),
+				desc:     "removes spaces after \\r",
+			},
+		}
+
+		for _, tt := range tests {
+			result := i.trimRight(tt.input)
+			if !bytes.Equal(result, tt.expected) {
+				t.Errorf("%s: trimRight(%q) = %q, want %q", tt.desc, tt.input, result, tt.expected)
+			}
+		}
+	})
+}
+
+func TestINI_Load_ErrorCases(t *testing.T) {
+	t.Run("invalid file path", func(t *testing.T) {
+		ini := NewINI("/nonexistent/path/file.txt") // Not .ini extension
+		_, err := ini.Load()
+		if err == nil {
+			t.Error("Load() should return error for invalid extension")
+		}
+	})
+
+	t.Run("cfg extension", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfgPath := filepath.Join(tmpDir, "test.cfg")
+
+		content := "[section]\nkey=value"
+		if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		ini := NewINI(cfgPath)
+		result, err := ini.Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if result["section.key"] != "value" {
+			t.Errorf("Expected section.key=value, got %v", result["section.key"])
+		}
+	})
+
+	t.Run("conf extension", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		confPath := filepath.Join(tmpDir, "test.conf")
+
+		content := "[section]\nkey=value"
+		if err := os.WriteFile(confPath, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		ini := NewINI(confPath)
+		result, err := ini.Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if result["section.key"] != "value" {
+			t.Errorf("Expected section.key=value, got %v", result["section.key"])
+		}
+	})
+}
+
 func TestINI_RealWorldExample(t *testing.T) {
 	content := `
 # Application Configuration

--- a/pkg/core/config/parser/xml.go
+++ b/pkg/core/config/parser/xml.go
@@ -212,37 +212,54 @@ func (x *XML) handleCharData(t xml.CharData, current, root *xmlNode) {
 func (x *XML) flattenXMLNode(node *xmlNode, prefix string, output map[string]string) {
 	for name, nodes := range node.children {
 		for i, child := range nodes {
-			var key string
-			if len(nodes) > 1 {
-				if prefix == "" {
-					key = fmt.Sprintf("%s.%d", name, i)
-				} else {
-					key = fmt.Sprintf("%s.%s.%d", prefix, name, i)
-				}
-			} else {
-				if prefix == "" {
-					key = name
-				} else {
-					key = fmt.Sprintf("%s.%s", prefix, name)
-				}
-			}
-
-			for _, attr := range child.attrs {
-				attrKey := fmt.Sprintf("%s.%s", key, attr.key)
-				output[attrKey] = attr.value
-			}
-
-			if child.value != "" {
-				output[key] = child.value
-			} else if len(child.children) == 0 {
-				// Empty element or self-closing tag
-				output[key] = ""
-			}
-
-			if len(child.children) > 0 {
-				x.flattenXMLNode(child, key, output)
-			}
+			key := x.buildNodeKey(name, i, len(nodes), prefix)
+			x.processNodeAttributes(child, key, output)
+			x.processNodeValue(child, key, output)
+			x.processChildNodes(child, key, output)
 		}
+	}
+}
+
+func (x *XML) buildNodeKey(name string, index, nodeCount int, prefix string) string {
+	if nodeCount > 1 {
+		return x.buildIndexedKey(name, index, prefix)
+	}
+	return x.buildSimpleKey(name, prefix)
+}
+
+func (x *XML) buildIndexedKey(name string, index int, prefix string) string {
+	if prefix == "" {
+		return fmt.Sprintf("%s.%d", name, index)
+	}
+	return fmt.Sprintf("%s.%s.%d", prefix, name, index)
+}
+
+func (x *XML) buildSimpleKey(name, prefix string) string {
+	if prefix == "" {
+		return name
+	}
+	return fmt.Sprintf("%s.%s", prefix, name)
+}
+
+func (x *XML) processNodeAttributes(child *xmlNode, key string, output map[string]string) {
+	for _, attr := range child.attrs {
+		attrKey := fmt.Sprintf("%s.%s", key, attr.key)
+		output[attrKey] = attr.value
+	}
+}
+
+func (x *XML) processNodeValue(child *xmlNode, key string, output map[string]string) {
+	if child.value != "" {
+		output[key] = child.value
+	} else if len(child.children) == 0 {
+		// Empty element or self-closing tag
+		output[key] = ""
+	}
+}
+
+func (x *XML) processChildNodes(child *xmlNode, key string, output map[string]string) {
+	if len(child.children) > 0 {
+		x.flattenXMLNode(child, key, output)
 	}
 }
 

--- a/pkg/core/config/parser/xml_test.go
+++ b/pkg/core/config/parser/xml_test.go
@@ -295,6 +295,77 @@ func TestXML_LoadReader_ErrorReading(t *testing.T) {
 	}
 }
 
+func TestXML_BuildIndexedKey(t *testing.T) {
+	x := &XML{}
+
+	tests := []struct {
+		name     string
+		nodeName string
+		index    int
+		prefix   string
+		want     string
+	}{
+		{
+			name:     "with prefix",
+			nodeName: "item",
+			index:    0,
+			prefix:   "root",
+			want:     "root.item.0",
+		},
+		{
+			name:     "without prefix",
+			nodeName: "item",
+			index:    1,
+			prefix:   "",
+			want:     "item.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := x.buildIndexedKey(tt.nodeName, tt.index, tt.prefix)
+			if got != tt.want {
+				t.Errorf("buildIndexedKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestXML_EstimateSize(t *testing.T) {
+	x := &XML{}
+
+	tests := []struct {
+		name string
+		data []byte
+		want int
+	}{
+		{
+			name: "small data returns minimum",
+			data: []byte("small"),
+			want: 32,
+		},
+		{
+			name: "large data calculates size",
+			data: make([]byte, 5000),
+			want: 100, // 5000 / 50
+		},
+		{
+			name: "empty data returns minimum",
+			data: []byte{},
+			want: 32,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := x.estimateSize(tt.data)
+			if got != tt.want {
+				t.Errorf("estimateSize() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestXML_AllTypes(t *testing.T) {
 	// Test ALL possible XML structures
 	content := `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary
- Reduced cyclomatic complexity in XML and INI parser methods
- Improved code maintainability without sacrificing performance

## Changes

### XML Parser (`flattenXMLNode`)
- Reduced complexity from 10 to under 8
- Split into focused helper functions:
  - `buildNodeKey`: Handles key construction logic
  - `processNodeAttributes`: Manages attribute processing
  - `processNodeValue`: Handles value assignment
  - `processChildNodes`: Manages recursive child processing

### INI Parser (`trimBytes`)
- Reduced complexity from 9 to under 8  
- Split into separate functions:
  - `trimLeftBytes`: Removes leading whitespace
  - `trimRightBytes`: Removes trailing whitespace
  - `isWhitespaceINI`: Character classification

## Test plan
- [x] All existing tests pass
- [x] No performance regression
- [x] Cyclomatic complexity reduced below thresholds