### PR TITLE
refactor: reduce method parameter count using context structs

### DIFF
--- a/pkg/core/config/normalize/normalize.go
+++ b/pkg/core/config/normalize/normalize.go
@@ -236,36 +236,46 @@ func estimateCapacity(m map[string]any) int {
 	return count
 }
 
+// flattenContext holds context for map flattening to reduce parameter count
+type flattenContext struct {
+	output     map[string]string
+	prefix     []string
+	keyBuilder *strings.Builder
+}
+
 func flattenRecursive(output map[string]string, input map[string]any,
 	prefix []string, keyBuilder *strings.Builder) {
+	ctx := &flattenContext{
+		output:     output,
+		prefix:     prefix,
+		keyBuilder: keyBuilder,
+	}
 	for key, value := range input {
 		keyBuilder.Reset()
 		buildKey(keyBuilder, prefix, key)
-		processValue(output, value, prefix, key, keyBuilder)
+		processValue(ctx, value, key)
 	}
 }
 
 // processValue handles different value types during flattening.
 // Dispatches to appropriate handlers based on value type:
 // maps are recursively flattened, arrays are indexed, and other values are stored.
-func processValue(output map[string]string, value any, prefix []string,
-	key string, keyBuilder *strings.Builder) {
+func processValue(ctx *flattenContext, value any, key string) {
 	switch v := value.(type) {
 	case map[string]any:
-		processMap(output, v, prefix, key, keyBuilder)
+		processMap(ctx, v, key)
 	case []any:
-		processSlice(output, v, prefix, key, keyBuilder)
+		processSlice(ctx, v, key)
 	default:
-		storeValue(output, keyBuilder.String(), value)
+		storeValue(ctx.output, ctx.keyBuilder.String(), value)
 	}
 }
 
 // processMap handles nested map values during flattening.
 // Creates a new prefix by appending the current key and recursively processes the map.
-func processMap(output map[string]string, m map[string]any, prefix []string,
-	key string, keyBuilder *strings.Builder) {
-	newPrefix := append(prefix, key)
-	flattenRecursive(output, m, newPrefix, keyBuilder)
+func processMap(ctx *flattenContext, m map[string]any, key string) {
+	newPrefix := append(ctx.prefix, key)
+	flattenRecursive(ctx.output, m, newPrefix, ctx.keyBuilder)
 }
 
 // buildKey constructs a dot-separated key from prefix and key.
@@ -292,20 +302,19 @@ func writePrefix(keyBuilder *strings.Builder, prefix []string) {
 // processSlice handles array/slice values during map flattening.
 // Array elements are indexed with dot notation (e.g., "key.0", "key.1").
 // Nested maps within arrays are recursively flattened.
-func processSlice(output map[string]string, slice []any, prefix []string,
-	key string, keyBuilder *strings.Builder) {
+func processSlice(ctx *flattenContext, slice []any, key string) {
 	for i, item := range slice {
-		keyBuilder.Reset()
-		buildArrayKey(keyBuilder, prefix, key, i)
+		ctx.keyBuilder.Reset()
+		buildArrayKey(ctx.keyBuilder, ctx.prefix, key, i)
 
 		// Process the array item
 		switch v := item.(type) {
 		case map[string]any:
 			itemKey := fmt.Sprintf("%s.%d", key, i)
-			newPrefix := append(prefix, itemKey)
-			flattenRecursive(output, v, newPrefix, keyBuilder)
+			newPrefix := append(ctx.prefix, itemKey)
+			flattenRecursive(ctx.output, v, newPrefix, ctx.keyBuilder)
 		default:
-			storeValue(output, keyBuilder.String(), item)
+			storeValue(ctx.output, ctx.keyBuilder.String(), item)
 		}
 	}
 }

--- a/pkg/core/config/parser/json.go
+++ b/pkg/core/config/parser/json.go
@@ -189,6 +189,14 @@ type stackItem struct {
 	depth  int
 }
 
+// jsonProcessContext holds context for JSON processing to reduce parameter count
+type jsonProcessContext struct {
+	depth      int
+	stack      *[]stackItem
+	result     map[string]string
+	keyBuilder *strings.Builder
+}
+
 func (j *JSON) processConfig(config map[string]any, dataSize int) (map[string]string, error) {
 	estimatedSize := max(dataSize/30, 16)
 	result := make(map[string]string, estimatedSize)
@@ -198,11 +206,19 @@ func (j *JSON) processConfig(config map[string]any, dataSize int) (map[string]st
 
 	stack := []stackItem{{data: config, prefix: "", depth: 0}}
 
+	ctx := &jsonProcessContext{
+		depth:      0,
+		stack:      &stack,
+		result:     result,
+		keyBuilder: &keyBuilder,
+	}
+
 	for len(stack) > 0 {
 		current := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
+		ctx.depth = current.depth
 
-		if err := j.processStackItem(current, &stack, result, &keyBuilder); err != nil {
+		if err := j.processStackItem(current, ctx); err != nil {
 			return nil, err
 		}
 	}
@@ -211,13 +227,13 @@ func (j *JSON) processConfig(config map[string]any, dataSize int) (map[string]st
 }
 
 // processStackItem processes a single stack item.
-func (j *JSON) processStackItem(current stackItem, stack *[]stackItem, result map[string]string, keyBuilder *strings.Builder) error {
+func (j *JSON) processStackItem(current stackItem, ctx *jsonProcessContext) error {
 	needsDot := len(current.prefix) > 0
 
 	for key, value := range current.data {
-		fullKey := j.buildKey(keyBuilder, current.prefix, key, needsDot)
+		fullKey := j.buildKey(ctx.keyBuilder, current.prefix, key, needsDot)
 
-		if err := j.processValue(fullKey, value, current.depth, stack, result, keyBuilder); err != nil {
+		if err := j.processValue(fullKey, value, ctx); err != nil {
 			return err
 		}
 	}
@@ -236,48 +252,48 @@ func (j *JSON) buildKey(keyBuilder *strings.Builder, prefix, key string, needsDo
 }
 
 // processValue processes a single value based on its type.
-func (j *JSON) processValue(fullKey string, value any, depth int, stack *[]stackItem, result map[string]string, keyBuilder *strings.Builder) error {
+func (j *JSON) processValue(fullKey string, value any, ctx *jsonProcessContext) error {
 	switch v := value.(type) {
 	case string:
-		result[normalize.Key(fullKey)] = normalize.Value(v)
+		ctx.result[normalize.Key(fullKey)] = normalize.Value(v)
 	case map[string]any:
-		return j.processMap(fullKey, v, depth, stack)
+		return j.processMap(fullKey, v, ctx)
 	case []any:
-		return j.processArray(fullKey, v, depth, stack, result, keyBuilder)
+		return j.processArray(fullKey, v, ctx)
 	case json.Number:
-		result[normalize.Key(fullKey)] = normalizeJSONNumber(v)
+		ctx.result[normalize.Key(fullKey)] = normalizeJSONNumber(v)
 	case float64:
-		result[normalize.Key(fullKey)] = fastFloat64ToString(v)
+		ctx.result[normalize.Key(fullKey)] = fastFloat64ToString(v)
 	case bool:
-		result[normalize.Key(fullKey)] = strconv.FormatBool(v)
+		ctx.result[normalize.Key(fullKey)] = strconv.FormatBool(v)
 	case nil:
-		result[normalize.Key(fullKey)] = ""
+		ctx.result[normalize.Key(fullKey)] = ""
 	default:
-		result[normalize.Key(fullKey)] = normalize.Value(fmt.Sprint(v))
+		ctx.result[normalize.Key(fullKey)] = normalize.Value(fmt.Sprint(v))
 	}
 	return nil
 }
 
 // processMap handles nested map processing.
-func (j *JSON) processMap(fullKey string, data map[string]any, depth int, stack *[]stackItem) error {
-	if depth >= MaxJSONDepth {
+func (j *JSON) processMap(fullKey string, data map[string]any, ctx *jsonProcessContext) error {
+	if ctx.depth >= MaxJSONDepth {
 		return ErrJSONParse.Newf("JSON nesting depth exceeds maximum: %d", MaxJSONDepth)
 	}
-	*stack = append(*stack, stackItem{data: data, prefix: fullKey, depth: depth + 1})
+	*ctx.stack = append(*ctx.stack, stackItem{data: data, prefix: fullKey, depth: ctx.depth + 1})
 	return nil
 }
 
 // processArray handles array processing.
-func (j *JSON) processArray(fullKey string, arr []any, depth int, stack *[]stackItem, result map[string]string, keyBuilder *strings.Builder) error {
+func (j *JSON) processArray(fullKey string, arr []any, ctx *jsonProcessContext) error {
 	for i, item := range arr {
-		itemKey := j.buildArrayKey(keyBuilder, fullKey, i)
+		itemKey := j.buildArrayKey(ctx.keyBuilder, fullKey, i)
 
 		if subMap, ok := item.(map[string]any); ok {
-			if err := j.processMap(itemKey, subMap, depth, stack); err != nil {
+			if err := j.processMap(itemKey, subMap, ctx); err != nil {
 				return err
 			}
 		} else {
-			result[normalize.Key(itemKey)] = normalizeAnyValue(item)
+			ctx.result[normalize.Key(itemKey)] = normalizeAnyValue(item)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary
- Reduced method parameter count from 5-6 to 3 parameters maximum
- Improved code maintainability and readability

## Changes

### JSON Parser
- Created `jsonProcessContext` struct to encapsulate processing state
- Reduced parameters in:
  - `processValue`: 6 → 3 parameters
  - `processStackItem`: 5 → 2 parameters  
  - `processMap`: 4 → 3 parameters
  - `processArray`: 6 → 3 parameters

### Normalize Package
- Created `flattenContext` struct for flattening operations
- Reduced parameters in:
  - `processValue`: 5 → 3 parameters
  - `processMap`: 5 → 3 parameters
  - `processSlice`: 5 → 3 parameters

## Benefits
- Cleaner function signatures
- Easier to maintain and extend
- Better encapsulation of related data
- No performance impact

## Test plan
- [x] All existing tests pass
- [x] No functional changes
- [x] No performance regression