### PR TITLE
fix: update BENCH tag to latest commit on each pipeline run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,16 @@ jobs:
 
           echo "✅ Benchmarks database ready"
 
+      - name: 🏷️ Update BENCH tag
+        run: |
+          # Delete the existing BENCH tag if it exists (both locally and remotely)
+          git tag -d BENCH 2>/dev/null || true
+          git push origin :refs/tags/BENCH 2>/dev/null || true
+          
+          # Create new BENCH tag at current commit
+          git tag BENCH
+          git push origin BENCH
+
       - name: 🚀 Create/Update BENCH Release
         uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # v1.14.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
           # Delete the existing BENCH tag if it exists (both locally and remotely)
           git tag -d BENCH 2>/dev/null || true
           git push origin :refs/tags/BENCH 2>/dev/null || true
-          
+
           # Create new BENCH tag at current commit
           git tag BENCH
           git push origin BENCH

--- a/README.md
+++ b/README.md
@@ -1,0 +1,208 @@
+# Kitsunium SDK
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/kitsunium/sdk.svg)](https://pkg.go.dev/github.com/kitsunium/sdk)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/b938f8b73d184cc7b6b298a18f16bc27)](https://app.codacy.com/gh/kitsunium/sdk/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![Codacy Coverage](https://app.codacy.com/project/badge/Coverage/b938f8b73d184cc7b6b298a18f16bc27)](https://app.codacy.com/gh/kitsunium/sdk/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![CI](https://github.com/kitsunium/sdk/workflows/CI/badge.svg)](https://github.com/kitsunium/sdk/actions)
+
+A high-performance Go SDK providing essential building blocks for modern applications with a focus on efficiency, reliability, and developer experience.
+
+## 🚀 Features
+
+### Core Packages
+
+#### 🔧 **Kernel Components**
+
+- **kbuffer**: High-performance buffer pool management with zero-allocation optimization
+- **kcache**: Advanced caching with LRU, sharded, and atomic cache implementations
+- **kerror**: Comprehensive error handling with stack traces and error registry
+- **kfs**: File system utilities with optimized file operations
+
+#### 📦 **Core Utilities**
+
+- **Config Management**: Multi-format configuration parser (YAML, JSON, TOML, XML, INI)
+- **Config Normalization**: Automatic configuration key normalization
+- **Performance Optimized**: Extensive benchmarking and performance tuning
+
+## 📊 Performance
+
+The SDK is extensively benchmarked for optimal performance. Run benchmarks with:
+
+```bash
+make bench                    # Benchmark current commit
+make bench <commit>          # Benchmark specific commit
+make bench/compare           # Compare with main branch
+make bench/compare <c1> <c2>  # Compare two commits
+```
+
+## 🛠️ Installation
+
+```bash
+go get github.com/kitsunium/sdk
+```
+
+## 📖 Usage
+
+### Buffer Pool Example
+
+```go
+import "github.com/kitsunium/sdk/pkg/kernel/kbuffer"
+
+// Create a buffer pool
+pool := kbuffer.NewPool(1024)
+
+// Get a buffer
+buf := pool.Get()
+defer pool.Put(buf)
+
+// Use the buffer
+buf.WriteString("Hello, World!")
+data := buf.Bytes()
+```
+
+### LRU Cache Example
+
+```go
+import "github.com/kitsunium/sdk/pkg/kernel/kcache"
+
+// Create an LRU cache with 1000 entries
+cache := kcache.NewLRU(1000)
+
+// Set a value
+cache.Set("key", "value")
+
+// Get a value
+if val, ok := cache.Get("key"); ok {
+    fmt.Println(val)
+}
+```
+
+### Error Handling Example
+
+```go
+import "github.com/kitsunium/sdk/pkg/kernel/kerror"
+
+// Define custom errors
+var (
+    ErrNotFound = kerror.New(404, "NOT_FOUND", "Resource not found")
+    ErrInternal = kerror.New(500, "INTERNAL", "Internal server error")
+)
+
+// Use errors with context
+err := ErrNotFound.WithDetail("user_id", userID)
+if kerror.Is(err, ErrNotFound) {
+    // Handle not found error
+}
+```
+
+### Configuration Parser Example
+
+```go
+import "github.com/kitsunium/sdk/pkg/core/config/parser"
+
+// Parse YAML configuration
+config, err := parser.YAML.LoadFile("config.yaml")
+
+// Parse JSON configuration
+data, err := parser.JSON.LoadBytes(jsonBytes)
+
+// Parse from environment variables
+envConfig, err := parser.ENV.Load("APP_")
+```
+
+## 🏗️ Development
+
+### Prerequisites
+
+- Go 1.21+
+- Bazel (optional, for build system)
+- Make
+
+### Building
+
+```bash
+make build              # Build all packages
+make test              # Run tests
+make test/coverage     # Run tests with coverage
+make quality/validate  # Run all quality checks
+```
+
+### Code Quality
+
+```bash
+make quality/lint      # Run linters
+make quality/format    # Format code
+make quality/security  # Run security analysis
+make quality/fix       # Auto-fix issues
+```
+
+### Git Hooks
+
+Install Git hooks for automatic code quality checks:
+
+```bash
+make hooks/install
+```
+
+## 📦 Package Structure
+
+```text
+sdk/
+├── pkg/
+│   ├── kernel/          # Core kernel packages
+│   │   ├── kbuffer/     # Buffer pool management
+│   │   ├── kcache/      # Caching implementations
+│   │   ├── kerror/      # Error handling
+│   │   ├── kfs/         # File system utilities
+│   │   └── config/      # Configuration management
+│   └── core/            # Core utilities
+│       └── config/      # Configuration parsers
+│           ├── parser/  # Multi-format parsers
+│           └── normalize/ # Key normalization
+└── scripts/             # Development scripts
+```
+
+## 🤝 Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/AmazingFeature`)
+3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
+4. Push to the branch (`git push origin feature/AmazingFeature`)
+5. Open a Pull Request
+
+## 📈 Benchmarks
+
+The SDK includes comprehensive benchmarks for all performance-critical components:
+
+- **Buffer Operations**: Optimized for minimal allocations
+- **Cache Operations**: Sub-microsecond access times
+- **Error Handling**: Zero-allocation error creation
+- **Config Parsing**: Fast multi-format parsing
+
+View the latest benchmark results:
+
+```bash
+make bench/list        # List saved benchmarks
+make bench/compare     # Compare performance
+```
+
+## 📄 License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+
+## 🔗 Links
+
+- [Documentation](https://pkg.go.dev/github.com/kitsunium/sdk)
+- [GitHub Repository](https://github.com/kitsunium/sdk)
+- [Issue Tracker](https://github.com/kitsunium/sdk/issues)
+
+## ⭐ Support
+
+If you find this project useful, please consider giving it a star on GitHub!
+
+---
+
+Made with ❤️ by the Kitsunium Team

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/kitsunium/sdk/workflows/CI/badge.svg)](https://github.com/kitsunium/sdk/actions)
 
-A high-performance Go SDK providing essential building blocks for modern applications with a focus on efficiency, reliability, and developer experience.
+A high-performance Go SDK providing essential building blocks for modern
+applications with a focus on efficiency, reliability, and developer experience.
 
 ## 🚀 Features
 
@@ -14,14 +15,17 @@ A high-performance Go SDK providing essential building blocks for modern applica
 
 #### 🔧 **Kernel Components**
 
-- **kbuffer**: High-performance buffer pool management with zero-allocation optimization
-- **kcache**: Advanced caching with LRU, sharded, and atomic cache implementations
+- **kbuffer**: High-performance buffer pool management with zero-allocation
+  optimization
+- **kcache**: Advanced caching with LRU, sharded, and atomic cache
+  implementations
 - **kerror**: Comprehensive error handling with stack traces and error registry
 - **kfs**: File system utilities with optimized file operations
 
 #### 📦 **Core Utilities**
 
-- **Config Management**: Multi-format configuration parser (YAML, JSON, TOML, XML, INI)
+- **Config Management**: Multi-format configuration parser (YAML, JSON, TOML,
+  XML, INI)
 - **Config Normalization**: Automatic configuration key normalization
 - **Performance Optimized**: Extensive benchmarking and performance tuning
 
@@ -175,7 +179,8 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## 📈 Benchmarks
 
-The SDK includes comprehensive benchmarks for all performance-critical components:
+The SDK includes comprehensive benchmarks for all performance-critical
+components:
 
 - **Buffer Operations**: Optimized for minimal allocations
 - **Cache Operations**: Sub-microsecond access times
@@ -189,9 +194,35 @@ make bench/list        # List saved benchmarks
 make bench/compare     # Compare performance
 ```
 
+## 🛡️ Development Setup
+
+### Git Hooks
+
+This project uses Git hooks to maintain code quality and enforce standards.
+Install them with:
+
+```bash
+# Install git hooks (required for contributors)
+bash .githooks/install.sh
+```
+
+The hooks will:
+
+- **pre-commit**: Format code automatically
+- **commit-msg**: Validate conventional commit format
+- **pre-push**: Block AI-related content
+
+To temporarily bypass hooks (not recommended):
+
+```bash
+git commit --no-verify  # Skip pre-commit
+ALLOW_AI_MENTIONS=1 git push  # Skip AI content check
+```
+
 ## 📄 License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the Apache License 2.0 - see the
+[LICENSE](LICENSE) file for details.
 
 ## 🔗 Links
 

--- a/scripts/bench_manager.py
+++ b/scripts/bench_manager.py
@@ -294,8 +294,8 @@ class BenchmarkManager:
         self._check_single_commit(cursor, base_commit, "Base")
         self._check_single_commit(cursor, current_commit, "Current")
         
-        print(f"\n{YELLOW}Run 'make bench-list' to see available commits{NC}")
-        print(f"{YELLOW}Run 'make bench-save' to save current benchmark results{NC}")
+        print(f"\n{YELLOW}Run 'make bench/list' to see available commits{NC}")
+        print(f"{YELLOW}Run 'make bench/save' to save current benchmark results{NC}")
         sys.exit(1)
 
     def _check_single_commit(self, cursor, commit: str, label: str):
@@ -639,7 +639,7 @@ class BenchmarkManager:
     def _print_no_results_message(self):
         """Print message when no results found."""
         print(f"{RED}❌ No benchmark results found{NC}")
-        print(f"{YELLOW}Run 'make bench-save' to save benchmark results{NC}")
+        print(f"{YELLOW}Run 'make bench/save' to save benchmark results{NC}")
 
     def _print_commits_header(self, rows: List[Tuple], limit: int):
         """Print commits list header."""


### PR DESCRIPTION
## Summary
- Fix BENCH tag not updating to latest commit when it already exists
- Update Codacy badges with correct project IDs  
- Fix make command references in bench_manager.py
- Resolve markdown linting issues

## Problem
When the BENCH tag already exists in the repository, the CI pipeline was not moving it to the latest commit on main branch. This caused the benchmark database download to always fetch an outdated version.

## Solution
Added a new step in the CI workflow that:
1. Deletes the existing BENCH tag (both locally and remotely)
2. Recreates the BENCH tag at the current commit
3. Pushes the updated tag before creating/updating the release

## Test plan
- [ ] CI pipeline runs successfully on main branch
- [ ] BENCH tag is updated to latest commit after pipeline completion
- [ ] `make bench/update` downloads the latest benchmark database
- [ ] Codacy badges display correctly in README
- [ ] No markdown linting warnings