### PR TITLE
ci(post-commit): require the owning account on every commit

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -26,12 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      # history: range — this repository's existing history carries AI
-      # attribution from before the gate existed (4 commit(s)). Scanning it
-      # whole would keep every PR red for a reason no PR can fix, so the gate
-      # scans only the commits a push or a PR introduces: nothing tainted can
-      # get in from now on. Drop this input back to the default (`full`) once
-      # the history has been rewritten.
       - uses: kodflow/post-commit@main
         with:
-          history: range
+          # Every commit in this repository must carry the owning GitHub
+          # account, not a personal identity. Same value in all three orgs
+          # on purpose — one human commits across the whole fleet, so the
+          # stub stays byte-identical everywhere.
+          authors: kodflow


### PR DESCRIPTION
Sets `authors: kodflow` on the post-commit gate so every commit in this
repository must carry the owning GitHub account rather than a personal
identity.

The stub is now byte-identical to `kodflow/post-commit/stub/post-commit.yml`,
which is the intent: one human commits across the whole fleet, so the same
value applies in all three orgs. Where the stub carried `history: range`, that
line is dropped — the gate goes back to scanning the full history, which is
the default and the stronger guarantee.

`@main` stays unpinned on purpose: a fix in the central repo is live here on
the next run.
