### PR TITLE
ci(post-commit): group concurrency per pull request

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -26,11 +26,17 @@ on:
   # repository whether it is still clean; you have to push something to find out.
   workflow_dispatch:
 
-# One verdict at a time, per branch. Without this the ready_for_review retry
-# path lets an older run finish after a newer one: the stale failure would put
-# a pull request back into draft that the newer commit already fixed.
+# One verdict at a time. Without this the ready_for_review retry path lets an
+# older run finish after a newer one: the stale failure would put a pull
+# request back into draft that the newer commit already fixed.
+#
+# github.ref, not head_ref: on a pull request head_ref is the bare source
+# branch name, so two pull requests from different forks that happen to share a
+# branch name would land in the same group and cancel each other's verdict.
+# github.ref is refs/pull/<n>/merge there — one group per pull request — and
+# the branch ref on push and manual runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
A red status only refuses a merge where a ruleset can require it, and GitHub
declines rulesets on private repositories in Free-plan organisations. Draft
state has no such hole: GitHub refuses to merge a draft on every plan and for
admins too, so a failing gate now puts the pull request back into draft.

The drafting lives in its own job on purpose. Granting `pull-requests: write`
to the gate job would hand a write-capable token to `kodflow/post-commit@main`
— a mutable external reference — on every trigger. This job runs no action at
all, so the token never reaches it, and the gate job stays `contents: read`.